### PR TITLE
Hotfix: Lower height of Footer Banner

### DIFF
--- a/static/footer.css
+++ b/static/footer.css
@@ -7,7 +7,7 @@ footer {
     font-size: 14px;
     z-index: 0;
     width: 100%;
-    height: 7vh;
+    height: 3vh;
 
     user-select: none;
     -webkit-user-select: none;


### PR DESCRIPTION
Lower the height of footer banner because it's hiding the buttons